### PR TITLE
active turning: off-route distance calculation fix

### DIFF
--- a/client/src/common/api.js
+++ b/client/src/common/api.js
@@ -115,14 +115,5 @@ export const loadFileSaver = callback =>
     .then(response => callback(null, response))
     .catch(error => callback(error));
 
-// async loads turf/distance and turf/midpoint
-export const loadTurfModules = callback =>
-  Promise.all([
-    import('@turf/distance'),
-    import('@turf/midpoint'),
-  ])
-  .then(response => callback(null, response))
-  .catch(error => callback(error));
-
 // helper function to convert meters to miles
 export const metersToMiles = x => +parseFloat(x * 0.000621371).toFixed(2);


### PR DESCRIPTION
See issue #37 for longer narrative. When calculating how far one is off the route, this replaces the Turf code with Leaflet code for better accuracy with longer-vertex segments.

* Confirmed that this was an issue
* Reworked Leaflet code
* This removes need for Turf, see changes to api.js
* Compared distance results with Google Maps scalebar

