### PR TITLE
documentation fix, added some missing params

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,9 +120,11 @@ Note that [Foreman](https://www.theforeman.org/) is used to run the Node.JS serv
 The `.env` file should reside in the root level of this repo and contain the following:
 
 ```
-MAILCHIMP_API_KEY="<REDACTED>"
-MAILCHIMP_LIST_ID="<REDACTED>"
-NODE_ENV="development"
+export MAILCHIMP_API_KEY="<REDACTED>"
+export MAILCHIMP_LIST_ID="<REDACTED>"
+export CARTODB_USER="niles"
+export DBTABLE_EDGES="ecg_route_lines_prod"
+export NODE_ENV="development"
 ```
 
 When you run `npm run dev` in the root of this repo, `Foreman` will be used to expose these variables to Node.JS for use by `server.js`.


### PR DESCRIPTION
* Documentation update. The README was missing the `export` keyword so that `.env` content were being loaded into the shell but not the *environment* and thus child processes sucgh as node.

* Documentation update. The `.env` file description now includes the two CARTO settings.
