### PR TITLE
Add click/mouse behavior to ECG trail

### DIFF
--- a/client/scss/components/_leaflet-map.scss
+++ b/client/scss/components/_leaflet-map.scss
@@ -20,6 +20,11 @@
       margin-top: 0;
     }
 
+    &.clicktarget {
+      // crosshair to idnicate "click here!"
+      cursor: crosshair;
+    }
+
     // reposition & reset the scalebar control
     .leaflet-control-scale.leaflet-control {
       bottom: 25px;


### PR DESCRIPTION
Merging these changes for some testing. These add mouse hover and click effects to the ECG trail, showing tooltips and changing the cursor on hover, and opening a popup on click.
