### PR TITLE
Change config settings to use new routing server

### DIFF
--- a/client/src/actions/ecgRoutingActions.js
+++ b/client/src/actions/ecgRoutingActions.js
@@ -12,6 +12,8 @@ import {
   ROUTE_SEARCH_ERROR,
 } from '../common/actionTypes';
 
+import { ROUTER_API_URL } from '../common/config';
+
 import { locationGeocodeClear, elevationDataClear } from './index';
 
 // Requesting the nearest ECG segment node / coordinate
@@ -39,7 +41,7 @@ export const setRoutingLocation = (coords, distance, step) => ({
 // fetch action that makes a GET request to route/nearestpoint API endpoint
 // see server.js for more info
 export const fetchRoutingLocation = (step, lat, lng) => {
-  const url = `/route/nearestpoint/?lat=${lat}&lng=${lng}`;
+  const url = `${ROUTER_API_URL}nearestpoint/?lat=${lat}&lng=${lng}`;
 
   return (dispatch) => {
     dispatch(nearestSegmentRequest(step));
@@ -113,7 +115,7 @@ export const routeSearchError = error => ({
 // fetch action that makes a GET request to the route/directions API endpoint
 // see server.js for more info
 export const fetchRouteDirections = (startLat, startLng, endLat, endLng) => {
-  const url = `/route/directions/?slat=${startLat}&slng=${startLng}&tlat=${endLat}&tlng=${endLng}`;
+  const url = `${ROUTER_API_URL}directions/?slat=${startLat}&slng=${startLng}&tlat=${endLat}&tlng=${endLng}`;
 
   return (dispatch) => {
     dispatch(routeSearchRequest());

--- a/client/src/common/config.js
+++ b/client/src/common/config.js
@@ -43,3 +43,7 @@ export const maxGeoBounds = [[18.312811, -110.830078], [53.278353, -45.351563]];
 // some universal constants such as unit conversions
 export const METERS_TO_MILES = 1609;
 export const METERS_TO_FEET = 3.281;
+
+// the URL of the routing API server
+// export const ROUTER_API_URL = '/route/';
+export const ROUTER_API_URL = 'https://router.greenway.org/';


### PR DESCRIPTION
This PR from `routevaserver` will change the front-end to begin using the new pgRouting-based route server. The route maintainers have been using the new router's debugger system for a few weeks now and they gave the OK.
