### PR TITLE
GPX export -- wpt for alerts, rte for cues

### DIFF
--- a/client/src/common/api.js
+++ b/client/src/common/api.js
@@ -127,7 +127,7 @@ export const cartoSQLQuery = query =>
 
 // async loads togpx.js
 export const loadToGPX = callback =>
-  import('togpx')
+  import('../utils/togpx-custom')
     .then(response => callback(null, response))
     .catch(error => callback(error));
 

--- a/client/src/components/LeafletMap.jsx
+++ b/client/src/components/LeafletMap.jsx
@@ -732,8 +732,8 @@ class LeafletMap extends Component {
 
         const isnearby = shortestdistance / METERS_TO_MILES <= POIS_DISTANCE_FROM_ROUTE;
         if (isnearby) {
-            marker.options.poi.segmentid = segmentid;
-            marker.addTo(this.map.routepois);
+          marker.options.poi.segmentid = segmentid;
+          marker.addTo(this.map.routepois);
         }
       });
 

--- a/client/src/components/RouteDownload.jsx
+++ b/client/src/components/RouteDownload.jsx
@@ -6,6 +6,7 @@ import { logDownloadGPX } from '../common/googleAnalytics';
 
 const GPX_CREATOR_NAME = 'East Coast Greenway Map';
 const GPX_TRACK_NAME = 'Route';
+const GPX_ROUTE_POINTS_NAME = 'Cues';
 
 class RouteDownload extends Component {
   static propTypes = {
@@ -51,6 +52,7 @@ class RouteDownload extends Component {
       const it = {
         type: 'Feature',
         properties: {
+          rte: true, // GreenInfo extension, this point is a rtept and not a wpt
           name: feature.properties.transition.title,
           description: feature.properties.title,
         },
@@ -81,6 +83,7 @@ class RouteDownload extends Component {
       const it = {
         type: 'Feature',
         properties: {
+          rte: false, // GreenInfo extension, this point is a wpt and not a rtept
           name: `${poi.type}: ${poi.name}`,
           description: poi.description,
         },
@@ -114,6 +117,7 @@ class RouteDownload extends Component {
           creator: GPX_CREATOR_NAME,
           featureTitle,
           featureDescription,
+          rteName: GPX_ROUTE_POINTS_NAME,
         });
 
         loadFileSaver((fserror, fileSaver) => {

--- a/client/src/utils/togpx-custom/LICENSE
+++ b/client/src/utils/togpx-custom/LICENSE
@@ -1,0 +1,20 @@
+The MIT License (MIT)
+
+Copyright (c) 2013 Martin Raifer
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/client/src/utils/togpx-custom/README-MODIFIED.md
+++ b/client/src/utils/togpx-custom/README-MODIFIED.md
@@ -1,0 +1,8 @@
+This is based on togpx by Martin Raifer (tyrasd)
+
+https://github.com/tyrasd/togpx
+
+It has been modified for this use case, to assign point features to either the list of `wpt` features (the default & current behavior) or else as `rtept` elements in a `rte`.
+
+This is released under the same license as the original togpx. See LICENSE for details.
+

--- a/client/src/utils/togpx-custom/README.md
+++ b/client/src/utils/togpx-custom/README.md
@@ -1,0 +1,56 @@
+togpx
+=====
+
+Converts [GeoJSON](http://geojson.org/) to [GPX](http://www.topografix.com/gpx.asp).
+
+[![Build Status](https://secure.travis-ci.org/tyrasd/togpx.png)](https://travis-ci.org/tyrasd/togpx)
+
+Usage
+-----
+
+* as a command line tool:
+  
+        $ npm install -g togpx
+        $ togpx file.geojson > file.gpx
+  
+* as a nodejs library:
+  
+        $ npm install togpx
+  
+        var togpx = require('togpx');
+        togpx(geojson_data);
+  
+* as a browser library:
+  
+        <script src='togpx.js'></script>
+  
+        togpx(geojson_data);
+
+API
+---
+
+### `togpx( geojson, options )`
+
+* `geojson`: the GeoJSON data.
+* `options`: optional. The following options can be used:
+  * `creator`: Specify a [creator](http://www.topografix.com/gpx/1/1/#element_gpx) string that is used to specify the software that created the final GPX file. Default is `togpx`.
+  * `metadata`: An object containing [metadata](http://www.topografix.com/gpx/1/1/#type_metadataType) about the to be converted dataset. Will be included in the GPX in the `<metadata>` tag. Usefull for providing information like `copyright`, `time`, `desc`, etc.
+  * `featureTitle`: Defines a callback that is used to construct a title (`<name>`) for a given GeoJSON feature. The callback is called with the GeoJSON feature's `properties` object.
+  * `featureDescription`: Defines a callback that is used to construct a description (`<desc>`) for a given GeoJSON feature. The callback is called with the GeoJSON feature's `properties` object.
+  * `featureLink`: Defines a callback that is used to construct an URL (`<link>`) for a given GeoJSON feature. The callback is called with the GeoJSON feature's `properties` object.
+  * `featureCoordTimes`: Defines a callback that is called for each feature to determine timestamps of each coordinate. Gets called with the current feature as a parameter, must return an array of UTC ISO 8601 timestamp strings for each coordinate of the feature. Alternatively. this option can be a string, in which case the corresponding feature property is used to read the times array.
+
+The result is a string of GPX XML.
+
+GPX
+---
+
+The conversion from GeoJSON to GPX is (by definition) lossy, because not every GeoJSON feature can be represented with the simple data types present in GPX files and GPX does not support arbitrary feature properties. This library tries to convert as much geometry and information as possible:
+
+* Points are converted to [Waypoints](http://www.topografix.com/gpx/1/1/#type_wptType).
+* Lines are converted to [Tracks](http://www.topografix.com/gpx/1/1/#type_trkType).
+* (Multi)Polygons are represented as a [Track](http://www.topografix.com/gpx/1/1/#type_trkType) of their outline(s).
+* By default, the `name` tag of GPX elements will be determined by a simple heuristic that searches for the following GeoJSON properties to construct a meaningful title: `name`, `ref`, `id`
+* By default, the `desc` tag of GPX elements will be constructed by concatenating all respective GeoJSON properties.
+* Elevation is included in the output if the GeoJSON coordinates contain altitude as a third value (`[lon, lat, altitude]`)
+* Timestamps are included in the GPX output if the GeoJSON has a `times` or `coordTimes` property that is an array of UTC ISO 8601 timestamp strings. See the `featureCoordTimes` option for customizing this behaviour.

--- a/client/src/utils/togpx-custom/index.js
+++ b/client/src/utils/togpx-custom/index.js
@@ -1,0 +1,215 @@
+/* eslint-disable */
+var JXON = require("jxon");
+JXON.config({attrPrefix: '@'});
+
+function togpx( geojson, options ) {
+  options = (function (defaults, options) {
+    for (var k in defaults) {
+      if (options.hasOwnProperty(k))
+        defaults[k] = options[k];
+    }
+    return defaults;
+  })({
+    creator: "togpx",
+    metadata: undefined,
+    featureTitle: get_feature_title,
+    featureDescription: get_feature_description,
+    featureLink: undefined,
+    featureCoordTimes: get_feature_coord_times,
+    rteName: "route",
+  }, options || {});
+
+  // is featureCoordTimes is a string -> look for the specified property
+  if (typeof options.featureCoordTimes === 'string') {
+    var customTimesFieldKey = options.featureCoordTimes;
+    options.featureCoordTimes = function (feature) {
+      return feature.properties[customTimesFieldKey];
+    }
+  }
+
+  function get_feature_title(props) {
+    // a simple default heuristic to determine a title for a given feature
+    // uses a nested `tags` object or the feature's `properties` if present
+    // and then searchs for the following properties to construct a title:
+    // `name`, `ref`, `id`
+    if (!props) return "";
+    if (typeof props.tags === "object") {
+      var tags_title = get_feature_title(props.tags);
+      if (tags_title !== "")
+        return tags_title;
+    }
+    if (props.name)
+      return props.name;
+    if (props.ref)
+      return props.ref;
+    if (props.id)
+      return props.id;
+    return "";
+  }
+  function get_feature_description(props) {
+    // constructs a description for a given feature
+    // uses a nested `tags` object or the feature's `properties` if present
+    // and then concatenates all properties to construct a description.
+    if (!props) return "";
+    if (typeof props.tags === "object")
+      return get_feature_description(props.tags);
+    var res = "";
+    for (var k in props) {
+      if (typeof props[k] === "object")
+        continue;
+      res += k+"="+props[k]+"\n";
+    }
+    return res.substr(0,res.length-1);
+  }
+  function get_feature_coord_times(feature) {
+    if (!feature.properties) return null;
+    return feature.properties.times || feature.properties.coordTimes || null;
+  }
+  function add_feature_link(o, f) {
+    if (options.featureLink)
+      o.link = { "@href": options.featureLink(f.properties) }
+  }
+  // make gpx object
+  var gpx = {"gpx": {
+    "@xmlns":"http://www.topografix.com/GPX/1/1",
+    "@xmlns:xsi":"http://www.w3.org/2001/XMLSchema-instance",
+    "@xsi:schemaLocation":"http://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/1/1/gpx.xsd",
+    "@version":"1.1",
+    "metadata": null,
+    "wpt": [],
+    "rte": { "name": options.rteName, "rtept": [] },
+    "trk": [],
+  }};
+  if (options.creator)
+    gpx.gpx["@creator"] = options.creator;
+  if (options.metadata)
+    gpx.gpx["metadata"] = options.metadata;
+  else
+    delete options.metadata;
+
+  var features;
+  if (geojson.type === "FeatureCollection")
+    features = geojson.features;
+  else if (geojson.type === "Feature")
+    features = [geojson];
+  else
+    features = [{type:"Feature", properties: {}, geometry: geojson}];
+  features.forEach(function mapFeature(f) {
+    switch (f.geometry.type) {
+    // POIs
+    case "Point":
+    case "MultiPoint":
+      var coords = f.geometry.coordinates;
+      if (f.geometry.type == "Point") coords = [coords];
+      coords.forEach(function (coordinates) {
+
+        if (f.properties.rte) {
+          o = {
+            "@lat": coordinates[1],
+            "@lon": coordinates[0],
+            "name": options.featureTitle(f.properties),
+            "desc": options.featureDescription(f.properties)
+          };
+        } else {
+          o = {
+            "@lat": coordinates[1],
+            "@lon": coordinates[0],
+            "name": options.featureTitle(f.properties),
+            "cmt": options.featureDescription(f.properties)
+          };
+        }
+
+        if (coordinates[2] !== undefined) {
+          o.ele = coordinates[2];
+        }
+        add_feature_link(o,f);
+
+        // add point to either wpt or rte
+        if (f.properties.rte) gpx.gpx.rte.rtept.push(o);
+        else gpx.gpx.wpt.push(o);
+      });
+      break;
+    // LineStrings
+    case "LineString":
+    case "MultiLineString":
+      var coords = f.geometry.coordinates;
+      var times = options.featureCoordTimes(f);
+      if (f.geometry.type == "LineString") coords = [coords];
+      o = {
+        "name": options.featureTitle(f.properties),
+        "desc": options.featureDescription(f.properties)
+      };
+      add_feature_link(o,f);
+      o.trkseg = [];
+      coords.forEach(function(coordinates) {
+        var seg = {trkpt: []};
+        coordinates.forEach(function(c, i) {
+          var o = {
+            "@lat": c[1],
+            "@lon":c[0]
+          };
+          if (c[2] !== undefined) {
+            o.ele = c[2];
+          }
+          if (times && times[i]) {
+            o.time = times[i];
+          }
+          seg.trkpt.push(o);
+        });
+        o.trkseg.push(seg);
+      });
+      gpx.gpx.trk.push(o);
+      break;
+    // Polygons / Multipolygons
+    case "Polygon":
+    case "MultiPolygon":
+      o = {
+        "name": options.featureTitle(f.properties),
+        "desc": options.featureDescription(f.properties)
+      };
+      add_feature_link(o,f);
+      o.trkseg = [];
+      var coords = f.geometry.coordinates;
+      var times = options.featureCoordTimes(f);
+      if (f.geometry.type == "Polygon") coords = [coords];
+      coords.forEach(function(poly) {
+        poly.forEach(function(ring) {
+          var seg = {trkpt: []};
+          var i = 0;
+          ring.forEach(function(c) {
+            var o = {
+              "@lat": c[1],
+              "@lon":c[0]
+            };
+            if (c[2] !== undefined) {
+              o.ele = c[2];
+            }
+            if (times && times[i]) {
+              o.time = times[i];
+            }
+            i++;
+            seg.trkpt.push(o);
+          });
+          o.trkseg.push(seg);
+        });
+      });
+      gpx.gpx.trk.push(o);
+      break;
+    case "GeometryCollection":
+      f.geometry.geometries.forEach(function (geometry) {
+        var pseudo_feature = {
+          "properties": f.properties,
+          "geometry": geometry
+        };
+        mapFeature(pseudo_feature);
+      });
+      break;
+    default:
+      console.log("warning: unsupported geometry type: "+f.geometry.type);
+    }
+  });
+  gpx_str = JXON.stringify(gpx);
+  return gpx_str;
+};
+
+module.exports = togpx;

--- a/client/src/utils/togpx-custom/package.json
+++ b/client/src/utils/togpx-custom/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "togpx",
+  "version": "0.5.4",
+  "description": "convert geojson to gpx",
+  "main": "index.js",
+  "scripts": {
+    "pretest": "npm ls --depth=Infinity > /dev/null",
+    "test": "npm run test-node && npm run test-webkit",
+    "test-node": "mocha -R spec",
+    "test-webkit": "mocha-phantomjs test/index.html"
+  },
+  "bin": {
+    "togpx": "togpx"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/tyrasd/togpx.git"
+  },
+  "keywords": [
+    "gpx",
+    "geojson"
+  ],
+  "author": "Martin Raifer",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/tyrasd/togpx/issues"
+  },
+  "dependencies": {
+    "concat-stream": "~1.0.1",
+    "jxon": "~2.0.0-beta.5",
+    "optimist": "~0.3.5",
+    "xmldom": "~0.1.17"
+  },
+  "devDependencies": {
+    "expect.js": "~0.2.0",
+    "mocha": "~2.1.0",
+    "mocha-phantomjs": "^4.1.0"
+  },
+  "browser": {
+    "xmldom": false
+  }
+}


### PR DESCRIPTION
Improves the GPX export per feedback.

* The turning cues are now `rtept` under a rte` to form a sequential list of route cues
* Alert POIs are still `wpt` entries since they have no clear sequence, nor clear connection to any specific turning cue

This should improve the compatibility with GPSs which use `rte` for cues.