### PR TITLE
Click map to select start/end points & Drag markers to change route

### DIFF
--- a/client/src/actions/geocodeActions.js
+++ b/client/src/actions/geocodeActions.js
@@ -9,6 +9,8 @@ import {
   LOCATION_GEOCODE_SUCCESS,
   LOCATION_GEOCODE_ERROR,
   LOCATION_GEOCODE_CLEAR,
+  LOCATION_GEOCODE_ZOOMMAP_ENABLE,
+  LOCATION_GEOCODE_ZOOMMAP_DISABLE,
 } from '../common/actionTypes';
 
 // we are about to make a GET request to geocode a location
@@ -32,6 +34,13 @@ export const locationGeocodeError = error => ({
 // user canceled the geo routing search process, reset the geocode state
 export const locationGeocodeClear = () => ({
   type: LOCATION_GEOCODE_CLEAR,
+});
+
+// toggle the zoom-to map behavior when a geocode is done
+// disabling is useful e.g. when dragging a marker to change one end
+// when zooming in to the points is disturbing UX
+export const setMapZoomOnGeocode = trueorfalse => ({
+  type: trueorfalse ? LOCATION_GEOCODE_ZOOMMAP_ENABLE : LOCATION_GEOCODE_ZOOMMAP_DISABLE,
 });
 
 /*

--- a/client/src/actions/index.js
+++ b/client/src/actions/index.js
@@ -1,5 +1,5 @@
 // Redux Actions, for more info see: http://redux.js.org/docs/basics/Actions.html
-export fetchLocationGeocode, { locationGeocodeError, locationGeocodeClear } from './geocodeActions';
+export fetchLocationGeocode, { locationGeocodeError, locationGeocodeClear, setMapZoomOnGeocode } from './geocodeActions';
 export {
   nearestSegmentRequest,
   nearestSegmentError,

--- a/client/src/common/actionTypes.js
+++ b/client/src/common/actionTypes.js
@@ -1,10 +1,13 @@
 // Redux Action Types, see: http://redux.js.org/docs/basics/Actions.html
 
 // Geocoding a search location
+// including a flag whether we should zoom the map to show locations
 export const LOCATION_GEOCODE_REQUEST = 'LOCATION_GEOCODE_REQUEST';
 export const LOCATION_GEOCODE_SUCCESS = 'LOCATION_GEOCODE_SUCCESS';
 export const LOCATION_GEOCODE_ERROR = 'LOCATION_GEOCODE_ERROR';
 export const LOCATION_GEOCODE_CLEAR = 'LOCATION_GEOCODE_CLEAR';
+export const LOCATION_GEOCODE_ZOOMMAP_ENABLE = 'LOCATION_GEOCODE_ZOOMMAP_ENABLE';
+export const LOCATION_GEOCODE_ZOOMMAP_DISABLE = 'LOCATION_GEOCODE_ZOOMMAP_DISABLE';
 
 // UX flow for selecting a ECG Route start and end location:
 // requesting, setting, accepting, canceling, and erroring

--- a/client/src/components/LeafletMap.jsx
+++ b/client/src/components/LeafletMap.jsx
@@ -73,6 +73,7 @@ class LeafletMap extends Component {
     lng: PropTypes.number.isRequired,
     zoom: PropTypes.number.isRequired,
     onMapMove: PropTypes.func.isRequired,
+    fetchLocationGeocode: PropTypes.func.isRequired,
     geocodeResult: PropTypes.object,
     startLocation: PropTypes.object,
     endLocation: PropTypes.object,
@@ -343,6 +344,20 @@ class LeafletMap extends Component {
 
     // set up the CARTO layer with the trail
     this.initCartoLayer();
+
+    // click handler on the map, to fill in a startLocation or endLocation if we don't have one yet
+    // as an alternative to typing an address for geocoding
+    // the input boxes and geocoder accept string "lng,lat" so we can just drop the click coords in
+    this.map.on('click', (event) => {
+      const { startLocation, endLocation, fetchLocationGeocode } = this.props;
+
+      const coordstring = `${event.latlng.lat.toFixed(6)},${event.latlng.lng.toFixed(6)}`;
+      if (!startLocation.accepted) {
+        fetchLocationGeocode(coordstring, true);
+      } else if (!endLocation.accepted) {
+        fetchLocationGeocode(coordstring, true);
+      }
+    });
   }
 
   initFakeGeolocationClicks() {

--- a/client/src/components/SearchBox/SearchInput.jsx
+++ b/client/src/components/SearchBox/SearchInput.jsx
@@ -44,6 +44,7 @@ class SearchInput extends Component {
   }
 
   handleSubmit(e) {
+    // FYI map click behavior instead of address: see LeafletMap and fetchLocationGeocode()
     const { searchAddress } = this.state;
     const { startLocation, endLocation, fetchLocationGeocode,
       cancelRoutingLocation, isLoadingRoute } = this.props;
@@ -96,9 +97,9 @@ class SearchInput extends Component {
     const { startLocation, endLocation } = this.props;
     let text = '';
 
-    if (!startLocation.accepted && !endLocation.accepted) text = 'Search a Starting Point';
-    if (startLocation.accepted && !endLocation.accepted) text = 'Search an Ending Point';
-    if (startLocation.accepted && endLocation.accepted) text = 'Search Again';
+    if (!startLocation.accepted && !endLocation.accepted) text = 'Search Starting Point or Click Map';
+    if (startLocation.accepted && !endLocation.accepted) text = 'Search Ending Point or Click Map';
+    if (startLocation.accepted && endLocation.accepted) text = 'Search Again or Click X to Clear';
 
     return text;
   }

--- a/client/src/components/SearchBox/SearchResults.jsx
+++ b/client/src/components/SearchBox/SearchResults.jsx
@@ -37,6 +37,7 @@ class SearchResults extends Component {
       PropTypes.object
     ]),
     geocodeResult: PropTypes.object,
+    zoomMapToGeocodes: PropTypes.bool.isRequired,
     isMobile: PropTypes.bool.isRequired,
     startLocation: PropTypes.object,
     endLocation: PropTypes.object,
@@ -138,7 +139,9 @@ class SearchResults extends Component {
   renderSearchResultsStep() {
     // handles which step of the Search UX Flow to display using application state
     const { geocodeError, geocodeResult, geocodeIsFetching, isMobile, startLocation,
-      endLocation, acceptRoutingLocation, route } = this.props;
+      endLocation, acceptRoutingLocation, zoomMapToGeocodes, route } = this.props;
+
+    // zoomMapToGeocodes = hide the Accept location prompts when we drag markers to recalculate
 
     if (geocodeIsFetching || startLocation.isFetching || endLocation.isFetching) {
       // loading message for when location is being searched
@@ -155,8 +158,8 @@ class SearchResults extends Component {
       return <ErrorMsg error={startLocation.error} />;
     }
 
-    if (startLocation.distance && !startLocation.accepted) {
-      return <StartLocationOptions {...{ geocodeResult, startLocation, acceptRoutingLocation }} />;
+    if (startLocation.distance && !startLocation.accepted && zoomMapToGeocodes) {
+      return <StartLocationOptions {...{ geocodeResult, startLocation, acceptRoutingLocation }} />; // eslint-disable-line max-len
     }
 
     if (startLocation.accepted && !endLocation.coordinates.length) {
@@ -164,8 +167,8 @@ class SearchResults extends Component {
       // see issue #50
     }
 
-    if (endLocation.coordinates.length && !endLocation.accepted) {
-      return <EndLocationOptions {...{ endLocation, geocodeResult, acceptRoutingLocation }} />;
+    if (endLocation.coordinates.length && !endLocation.accepted && zoomMapToGeocodes) {
+      return <EndLocationOptions {...{ endLocation, geocodeResult, acceptRoutingLocation }} />; // eslint-disable-line max-len
     }
 
     if (!isMobile && endLocation.accepted && startLocation.accepted) {

--- a/client/src/components/SearchBox/SearchResults.jsx
+++ b/client/src/components/SearchBox/SearchResults.jsx
@@ -59,7 +59,7 @@ class SearchResults extends Component {
     const { startLocation, endLocation, route } = this.props;
 
     // check for preloaded state with start and end locations, if they exist tell
-    // the geoRouter to find a route between them asyc
+    // the geoRouter to find a route between them asynchronously
     if (endLocation.accepted && endLocation.coordinates.length && startLocation.accepted
       && startLocation.coordinates.length && !route.response) {
       this.routeSearchStartTime = new Date();

--- a/client/src/containers/LeafletMapConnected.jsx
+++ b/client/src/containers/LeafletMapConnected.jsx
@@ -4,7 +4,7 @@ import { connect } from 'react-redux';
 
 import LeafletMap from '../components/LeafletMap';
 
-import { updateActiveTurning, disableActiveTurning, reportLocationError, selectPoi, updateNearbyPois } from '../actions';
+import { updateActiveTurning, disableActiveTurning, reportLocationError, selectPoi, updateNearbyPois, fetchLocationGeocode } from '../actions';
 
 const mapStateToProps = ({ activeturning, browser, geocoding, routing }) => {
   const { enabled } = activeturning;
@@ -29,4 +29,5 @@ export default connect(mapStateToProps, {
   reportLocationError,
   selectPoi,
   updateNearbyPois,
+  fetchLocationGeocode,
 })(LeafletMap);

--- a/client/src/containers/LeafletMapConnected.jsx
+++ b/client/src/containers/LeafletMapConnected.jsx
@@ -4,18 +4,19 @@ import { connect } from 'react-redux';
 
 import LeafletMap from '../components/LeafletMap';
 
-import { updateActiveTurning, disableActiveTurning, reportLocationError, selectPoi, updateNearbyPois, fetchLocationGeocode, cancelRoutingLocation, acceptRoutingLocation } from '../actions';
+import { updateActiveTurning, disableActiveTurning, reportLocationError, selectPoi, updateNearbyPois, fetchLocationGeocode, cancelRoutingLocation, acceptRoutingLocation, setMapZoomOnGeocode } from '../actions';
 
 const mapStateToProps = ({ activeturning, browser, geocoding, routing }) => {
   const { enabled } = activeturning;
   const { greaterThan } = browser;
-  const { error, result } = geocoding;
+  const { error, result, zoomMapToGeocodes } = geocoding;
   const { startLocation, endLocation, route } = routing;
 
   return {
     activeTurningEnabled: enabled,
     geocodeError: error,
     geocodeResult: result,
+    zoomMapToGeocodes,
     isMobile: !greaterThan.medium,
     startLocation,
     endLocation,
@@ -32,4 +33,5 @@ export default connect(mapStateToProps, {
   fetchLocationGeocode,
   cancelRoutingLocation,
   acceptRoutingLocation,
+  setMapZoomOnGeocode,
 })(LeafletMap);

--- a/client/src/containers/LeafletMapConnected.jsx
+++ b/client/src/containers/LeafletMapConnected.jsx
@@ -4,7 +4,7 @@ import { connect } from 'react-redux';
 
 import LeafletMap from '../components/LeafletMap';
 
-import { updateActiveTurning, disableActiveTurning, reportLocationError, selectPoi, updateNearbyPois, fetchLocationGeocode } from '../actions';
+import { updateActiveTurning, disableActiveTurning, reportLocationError, selectPoi, updateNearbyPois, fetchLocationGeocode, cancelRoutingLocation, acceptRoutingLocation } from '../actions';
 
 const mapStateToProps = ({ activeturning, browser, geocoding, routing }) => {
   const { enabled } = activeturning;
@@ -30,4 +30,6 @@ export default connect(mapStateToProps, {
   selectPoi,
   updateNearbyPois,
   fetchLocationGeocode,
+  cancelRoutingLocation,
+  acceptRoutingLocation,
 })(LeafletMap);

--- a/client/src/containers/SearchResultsConnected.jsx
+++ b/client/src/containers/SearchResultsConnected.jsx
@@ -17,7 +17,7 @@ import {
 } from '../actions';
 
 const mapStateToProps = ({ browser, geocoding, routing }) => {
-  const { error, result, isFetching } = geocoding;
+  const { error, result, isFetching, zoomMapToGeocodes } = geocoding;
   const { endLocation, startLocation, route } = routing;
   const { greaterThan } = browser;
 
@@ -28,6 +28,7 @@ const mapStateToProps = ({ browser, geocoding, routing }) => {
     isMobile: !greaterThan.medium,
     endLocation,
     startLocation,
+    zoomMapToGeocodes,
     route
   };
 };

--- a/client/src/reducers/geocodeReducer.js
+++ b/client/src/reducers/geocodeReducer.js
@@ -4,13 +4,16 @@ import {
   LOCATION_GEOCODE_SUCCESS,
   LOCATION_GEOCODE_ERROR,
   LOCATION_GEOCODE_CLEAR,
+  LOCATION_GEOCODE_ZOOMMAP_ENABLE,
+  LOCATION_GEOCODE_ZOOMMAP_DISABLE,
 } from '../common/actionTypes';
 
 const defaultState = {
   isFetching: false,
   searchTerm: '',
   result: null,
-  error: null
+  error: null,
+  zoomMapToGeocodes: true,
 };
 
 const parseGeocodeResult = (result) => {
@@ -55,6 +58,18 @@ export default (state = defaultState, action) => {
 
     case LOCATION_GEOCODE_CLEAR:
       return { ...defaultState };
+
+    case LOCATION_GEOCODE_ZOOMMAP_ENABLE:
+      return {
+        ...state,
+        zoomMapToGeocodes: true,
+      };
+
+    case LOCATION_GEOCODE_ZOOMMAP_DISABLE:
+      return {
+        ...state,
+        zoomMapToGeocodes: false,
+      };
 
     default:
       return state;


### PR DESCRIPTION
1. In lieu of entering an address into the address box, you may click the map to define a location. It will then do the same as before: show the distance and a line, allow you to confirm.
2. With a completed route, the start/end markers can be dragged to change the route. I added a "don't zoom to the geocode points" behavior during this, so the map doesn't zoom in and out several times as it lays out your points.
