### PR TITLE
fix TCX download on mobile cue sheet

### DIFF
--- a/client/src/containers/CueSheetConnected.jsx
+++ b/client/src/containers/CueSheetConnected.jsx
@@ -4,9 +4,10 @@ import { connect } from 'react-redux';
 
 import CueSheet from '../views/CueSheet';
 
-const mapStateToProps = ({ browser, routing }) => ({
+const mapStateToProps = ({ browser, routing, elevation }) => ({
   isMobile: !browser.greaterThan.medium,
-  route: routing.route
+  route: routing.route,
+  elevData: elevation.result,
 });
 
 export default connect(mapStateToProps, null)(CueSheet);

--- a/client/src/views/CueSheet.jsx
+++ b/client/src/views/CueSheet.jsx
@@ -13,6 +13,7 @@ import { metersToMiles } from '../common/api';
 class CueSheet extends Component {
   static propTypes = {
     route: PropTypes.object,
+    elevData: PropTypes.array,
     isMobile: PropTypes.bool
   }
 
@@ -126,7 +127,7 @@ class CueSheet extends Component {
   }
 
   render() {
-    const { isMobile, route } = this.props;
+    const { isMobile, route, elevData } = this.props;
     const { response } = route;
     const header1 = isMobile ? 'Cum. miles' : 'Cumulative miles';
     const header2 = isMobile ? 'Seg. miles' : 'Segment miles';
@@ -140,7 +141,7 @@ class CueSheet extends Component {
               <div>
                 <p className="nav-link"><Link to="/">Back to Map</Link></p>
                 <button className="print" onClick={() => window.print()} />
-                <RouteDownloadTCX route={route} />
+                <RouteDownloadTCX route={route} elevData={elevData} />
                 <RouteDownloadGPX route={route} />
                 <table>
                   <thead>


### PR DESCRIPTION
Refer to https://github.com/EastCoastGreenwayAlliance/ecg-map/issues/106

On mobile, the TCX download button appears on the Cue Sheet. The Cue Sheet was not passing `elevData` like the DownloadSharePrint bar was, so this TCX button on mobile was not working.